### PR TITLE
Major changes to MLFF implementation

### DIFF
--- a/src/chemrefine/client.py
+++ b/src/chemrefine/client.py
@@ -17,9 +17,6 @@ end_import = time.perf_counter()
 
 def parse_extended_args(arglist):
     parser = argparse.ArgumentParser()
-    parser.add_argument("--model_name", type=str, default="uma-s-1")
-    parser.add_argument("--task_name", type=str, default="omol")
-    parser.add_argument("--device", type=str, default="cuda")
     parser.add_argument("--bind", type=str, default="127.0.0.1:8888")
     parser.add_argument("inputfile")
     return parser.parse_args(arglist)

--- a/src/chemrefine/core.py
+++ b/src/chemrefine/core.py
@@ -6,6 +6,7 @@ from .refine import StructureRefiner
 from .utils import Utility
 from .orca_interface import OrcaInterface, OrcaJobSubmitter
 import shutil
+import re
 import sys
 from chemrefine.utils import (
     write_step_manifest,

--- a/src/chemrefine/core.py
+++ b/src/chemrefine/core.py
@@ -69,7 +69,8 @@ class ChemRefiner:
                                 model_name=None, 
                                 task_name=None,
                                 device='cpu',
-                                bind='127.0.0.1:8888'):
+                                bind='127.0.0.1:8888',
+                                ):
         
         """ Prepares the directory for the first step by copying the initial XYZ file,"""
         if charge is None:
@@ -116,7 +117,7 @@ class ChemRefiner:
             model_name=model_name,
             task_name=task_name,
             device=device,
-            bind=bind
+            bind=bind,
         )
 
         return step_dir, input_files, output_files
@@ -131,7 +132,7 @@ class ChemRefiner:
                                           model_name=None, 
                                           task_name=None,
                                           device='cuda',
-                                          bind='127.0.0.1:8888'
+                                          bind='127.0.0.1:8888',
                                           ):
         """
         Prepares the directory for subsequent steps by writing XYZ files, copying the template input,
@@ -182,7 +183,8 @@ class ChemRefiner:
             model_name=model_name, 
             task_name=task_name,
             device=device,
-            bind=bind
+            bind=bind,
+            
         )
 
         return step_dir, input_files, output_files
@@ -474,8 +476,8 @@ class ChemRefiner:
                 engine=engine,
                 operation=operation,
                 model_name=model_name,
-                task_name=task_name
-                
+                task_name=task_name,
+                model_path=model_path
                
             )
         except Exception as e:
@@ -554,14 +556,19 @@ class ChemRefiner:
                 mlff_config = step.get('mlff', {})
                 mlff_model = mlff_config.get('model_name', 'medium')
                 mlff_task = mlff_config.get('task_name', 'mace_off')
+                mlff_model_path = mlff_config.get('model_path', None)
                 bind_address = mlff_config.get('bind', '127.0.0.1:8888')
                 device = mlff_config.get('device', 'cuda')
                 logging.info(f"Using MLFF model '{mlff_model}' with task '{mlff_task}' for step {step_id}.")
+                if mlff_model_path:
+                    logging.info(f"Custom MLFF model path specified {mlff_model_path}.")
             else:
-                mlff_model = step.get('model_name', 'medium')
-                mlff_task = step.get('task_name', 'mace_off')
-                bind_address = '127.0.0.1:8888'
-                device = 'cpu'
+               
+                mlff_model = None
+                mlff_task = None
+                mlff_model_path = None
+                bind_address = None
+                device = None
 
             sample_method = step['sample_type']['method']
             parameters = step['sample_type'].get('parameters', {})
@@ -589,7 +596,7 @@ class ChemRefiner:
                         model_name=mlff_model,
                         task_name=mlff_task,
                         device=device,
-                        bind=bind_address
+                        bind=bind_address,
                     )
                 else:
                     validate_structure_ids_or_raise(previous_ids, step_id)
@@ -604,7 +611,8 @@ class ChemRefiner:
                         model_name=mlff_model,
                         task_name=mlff_task,
                         device=device,
-                        bind=bind_address
+                        bind=bind_address,
+                       
                     )
 
                 # Save manifest with input structure IDs
@@ -619,7 +627,8 @@ class ChemRefiner:
                     engine=engine,
                     model_name=mlff_model,
                     task_name=mlff_task,
-                    device=device
+                    device=device,
+                    model_path = mlff_model_path
                 )
 
                 # Parse outputs

--- a/src/chemrefine/core.py
+++ b/src/chemrefine/core.py
@@ -7,6 +7,16 @@ from .utils import Utility
 from .orca_interface import OrcaInterface, OrcaJobSubmitter
 import shutil
 import sys
+from chemrefine.utils import (
+    write_step_manifest,
+    update_step_manifest_outputs,
+    map_outputs_to_ids,
+    extract_structure_id,
+    write_step_manifest,
+    write_synthetic_manifest_for_ensemble,
+    get_ensemble_ids,
+    validate_structure_ids_or_raise
+)
 
 class ChemRefiner:
 
@@ -176,67 +186,176 @@ class ChemRefiner:
 
         return step_dir, input_files, output_files
 
-    def handle_skip_step(self, step_number, operation,engine, sample_method, parameters):
+    def handle_skip_step(self, step_number, operation, engine, sample_method, parameters):
         """
-        Handles skip logic for a step if its directory already exists and required outputs are present.
+        Decide whether to skip a step by validating that expected outputs already exist.
+        Preserve persistent structure IDs using the step manifest when available.
+        If the manifest is missing (legacy runs), reconstruct IDs from current filenames
+        (e.g., 'stepN_structure_{ID}.*'); for GOAT-only ensembles, synthesize IDs [0..N-1].
+        
+        Parameters
+        ----------
+        step_number : int
+            Current step index.
+        operation : str
+            ORCA-level operation ("OPT+SP", "GOAT", "PES", "DOCKER", "SOLVATOR"), case-insensitive.
+        engine : str
+            Calculation engine ("dft" or "mlff").
+        sample_method : str
+            Refiner filtering method.
+        parameters : dict
+            Parameters for the filtering method.
 
-        Args:
-            step_number (int): The current step number.
-            operation (str): Algorithm used in ORCA (i.e GOAT, DOCKER, PES, OPT+SP).
-            engine (str): The calculation engine (e.g., 'dft', 'mlff
-            sample_method (str): The sampling method.
-            parameters (dict): Additional parameters for filtering.
-
-        Returns:
-            tuple: (filtered_coordinates, filtered_ids, energies) if step is skipped, else (None, None, None).
+        Returns
+        -------
+        tuple[list|None, list|None, list|None]
+            (filtered_coordinates, filtered_ids, energies) when outputs are reusable;
+            otherwise (None, None, None) to signal re-run.
         """
+        import os
+        import re
+        import logging
+
         step_dir = os.path.join(self.output_dir, f"step{step_number}")
-        if os.path.exists(step_dir):
-            logging.info(f"Checking skip condition for step {step_number} at: {step_dir}")
-
-            
-            if operation.lower() == 'goat':
-                output_files = [
-                    os.path.join(step_dir, f)
-                    for f in os.listdir(step_dir)
-                    if f.endswith('.finalensemble.xyz')
-                ]
-                if not output_files:
-                    logging.warning(f"No GOAT ensemble files found in {step_dir}. Will rerun this step.")
-                    return None, None,None
-                logging.info(f"Found {len(output_files)} GOAT ensemble file(s) in {step_dir}. Skipping this step.")
-
-            elif operation.lower() == 'docker':
-                output_files = [
-                    os.path.join(step_dir, f)
-                    for f in os.listdir(step_dir)
-                    if f.endswith('struc1.allopt.xyz')
-                ]
-                if not output_files:
-                    logging.warning(f"No GOAT ensemble files found in {step_dir}. Will rerun this step.")
-                    return None, None,None
-                logging.info(f"Found {len(output_files)} GOAT ensemble file(s) in {step_dir}. Skipping this step.")
-            else:
-                output_files = [
-                    os.path.join(step_dir, f)
-                    for f in os.listdir(step_dir)
-                    if f.endswith('.out') and not f.endswith('.smd.out') and not f.startswith('slurm')
-                ]
-                if not output_files:
-                    logging.warning(f"No .out files found in {step_dir}. Will rerun this step.")
-                    return None, None,None
-                logging.info(f"Found {len(output_files)} .out file(s) in {step_dir}. Skipping this step.")
-
-            coordinates, energies = self.orca.parse_output(output_files, operation, dir=step_dir)
-            logging.info(f"Parsed {len(coordinates)} coordinates and {len(energies)} energies from {output_files}.")
-            filtered_coordinates, filtered_ids = self.refiner.filter(
-                coordinates, energies, list(range(len(energies))), sample_method, parameters
-            )
-            logging.info(f"Filtered {len(filtered_coordinates)} coordinates and {len(filtered_ids)} IDs after filtering.")
-            return filtered_coordinates, filtered_ids, energies
-        else:
+        if not os.path.exists(step_dir):
             logging.info(f"Step directory {step_dir} does not exist. Will run this step.")
             return None, None, None
+
+        op = operation.strip().upper()
+
+        # -------- discover outputs by operation --------
+        if op == "GOAT":
+            output_files = [
+                os.path.join(step_dir, f)
+                for f in os.listdir(step_dir)
+                if f.endswith(".finalensemble.xyz")
+            ]
+            missing_msg = "No GOAT ensemble (.finalensemble.xyz) files found"
+            found_msg = f"Found {len(output_files)} GOAT ensemble file(s)"
+        elif op == "DOCKER":
+            output_files = [
+                os.path.join(step_dir, f)
+                for f in os.listdir(step_dir)
+                if f.endswith("struc1.allopt.xyz")
+            ]
+            missing_msg = "No DOCKER output (struc1.allopt.xyz) files found"
+            found_msg = f"Found {len(output_files)} DOCKER output file(s)"
+        elif op == "SOLVATOR":
+            candidates = [
+                os.path.join(step_dir, f)
+                for f in os.listdir(step_dir)
+                if f.lower() == "solvator.xyz"
+            ]
+            if not candidates:
+                candidates = [
+                    os.path.join(step_dir, f)
+                    for f in os.listdir(step_dir)
+                    if f.endswith(".xyz") and "solvator" in f.lower()
+                ]
+            output_files = candidates
+            missing_msg = "No SOLVATOR xyz files found"
+            found_msg = f"Found {len(output_files)} SOLVATOR xyz file(s)"
+        else:
+            # OPT+SP / PES: ORCA .out files (exclude SMD aux and slurm)
+            output_files = [
+                os.path.join(step_dir, f)
+                for f in os.listdir(step_dir)
+                if f.endswith(".out") and not f.endswith(".smd.out") and not f.startswith("slurm")
+            ]
+            missing_msg = "No ORCA .out files found"
+            found_msg = f"Found {len(output_files)} .out file(s)"
+
+        if not output_files:
+            logging.warning(f"{missing_msg} in {step_dir}. Will rerun this step.")
+            return None, None, None
+
+        logging.info(f"{found_msg} in {step_dir}. Reusing existing outputs.")
+
+        # Update manifest with outputs if present (noop if missing)
+        update_step_manifest_outputs(step_dir, step_number, output_files)
+
+        # -------- parse outputs --------
+        coordinates, energies = self.orca.parse_output(output_files, op, dir=step_dir)
+        if not coordinates or not energies or len(coordinates) != len(energies):
+            logging.warning(
+                f"Parsed outputs are incomplete or inconsistent for step {step_number} "
+                f"(coords={len(coordinates)}, energies={len(energies)}). Will rerun this step."
+            )
+            return None, None, None
+
+        # -------- resolve IDs --------
+        # 1) try manifest path
+        structure_ids = map_outputs_to_ids(step_dir, step_number, output_files)
+
+        # 2) if unresolved → reconstruct depending on step/operation
+        if all(i < 0 for i in structure_ids):
+            if op == "GOAT":
+                # One ensemble file → N structures; synthesize IDs aligned to ensemble order.
+                logging.info(f"No usable manifest for GOAT step {step_number}; synthesizing ensemble IDs.")
+                ensemble_base = os.path.basename(output_files[0])  # usually one file
+                n_structs = len(energies)
+                # Prefer helper if present; otherwise inline synthesize:
+                try:
+                    ids = get_ensemble_ids(
+                        step_dir=step_dir,
+                        step_number=step_number,
+                        n_structures=n_structs,
+                        operation=op,
+                        engine=engine,
+                        output_basename=ensemble_base,
+                    )
+                except NameError:
+                    # Fallback: write synthetic manifest directly
+                    write_synthetic_manifest_for_ensemble(
+                        step_number=step_number,
+                        step_dir=step_dir,
+                        n_structures=n_structs,
+                        operation=op,
+                        engine=engine,
+                        output_basename=ensemble_base,
+                    )
+                    ids = list(range(n_structs))
+                structure_ids = ids
+            else:
+                # Non-GOAT: per-structure files exist. Rebuild IDs from filenames.
+                logging.info(f"No manifest for step {step_number}; reconstructing IDs from filenames.")
+                # We can parse the ID from either *.inp or directly from the output stem.
+                # Pattern matches step{N}_structure_{ID} with any extension.
+                pat = re.compile(rf"^step{step_number}_structure_(\d+)$", re.IGNORECASE)
+                recovered_ids = []
+                recovered_inps = []
+                for outp in output_files:
+                    stem = os.path.splitext(os.path.basename(outp))[0]
+                    m = pat.match(stem)
+                    if m:
+                        sid = int(m.group(1))
+                        recovered_ids.append(sid)
+                        candidate_inp = os.path.join(step_dir, stem + ".inp")
+                        if os.path.exists(candidate_inp):
+                            recovered_inps.append(candidate_inp)
+                    else:
+                        # Try the .inp name directly through helper
+                        candidate_inp = os.path.join(step_dir, stem + ".inp")
+                        sid2 = extract_structure_id(candidate_inp)
+                        if sid2 is None:
+                            logging.warning(f"Could not resolve ID for {outp}; rerunning step.")
+                            return None, None, None
+                        recovered_ids.append(sid2)
+                        if os.path.exists(candidate_inp):
+                            recovered_inps.append(candidate_inp)
+
+                structure_ids = recovered_ids
+                # Persist recovered mapping so future skips are trivial
+                if recovered_inps:
+                    write_step_manifest(step_number, step_dir, recovered_inps, op, engine)
+                    update_step_manifest_outputs(step_dir, step_number, output_files)
+
+        # -------- filter with persistent/recovered IDs --------
+        filtered_coordinates, filtered_ids = self.refiner.filter(
+            coordinates, energies, structure_ids, sample_method, parameters
+        )
+        logging.info(f"After filtering step {step_number}: kept {len(filtered_coordinates)} structures.")
+        return filtered_coordinates, filtered_ids, energies
 
     def submit_orca_jobs(self, input_files, cores, step_dir,device='cpu',operation='OPT+SP',engine='DFT', model_name=None, task_name=None):
         """
@@ -316,7 +435,7 @@ class ChemRefiner:
         """
         Main pipeline execution function for ChemRefine.
         Dynamically loops over all steps defined in the YAML input.
-        Handles skip-step logic and standard pipeline logic.
+        Handles skip-step logic, ID persistence, and normal pipeline execution.
         """
         logging.info("Starting ChemRefine pipeline.")
         previous_coordinates, previous_ids = None, None
@@ -381,6 +500,7 @@ class ChemRefiner:
                         bind=bind_address
                     )
                 else:
+                    validate_structure_ids_or_raise(previous_ids, step_id)
                     step_dir, input_files, output_files = self.prepare_subsequent_step_directory(
                         step_id,
                         previous_coordinates,
@@ -395,6 +515,10 @@ class ChemRefiner:
                         bind=bind_address
                     )
 
+                # Save manifest with input structure IDs
+                write_step_manifest(step_id, step_dir, input_files, operation, engine)
+
+                # Submit jobs
                 self.submit_orca_jobs(
                     input_files,
                     self.max_cores,
@@ -406,14 +530,22 @@ class ChemRefiner:
                     device=device
                 )
 
-                filtered_coordinates, filtered_ids = self.parse_and_filter_outputs(
-                    output_files,
-                    operation,
-                    engine,
-                    step_id,
+                # Parse outputs
+                filtered_coordinates, energies = self.orca.parse_output(output_files, operation, dir=step_dir)
+
+                # Update manifest with output file names
+                update_step_manifest_outputs(step_dir, step_id, output_files)
+
+                # Get persistent IDs for outputs
+                filtered_ids = map_outputs_to_ids(step_dir, step_id, output_files)
+
+                # Apply filtering
+                filtered_coordinates, filtered_ids = self.refiner.filter(
+                    filtered_coordinates,
+                    energies,
+                    filtered_ids,
                     sample_method,
-                    parameters,
-                    step_dir
+                    parameters
                 )
 
                 if filtered_coordinates is None or filtered_ids is None:
@@ -423,6 +555,7 @@ class ChemRefiner:
                 step_dir = os.path.join(self.output_dir, f"step{step_id}")
                 logging.info(f"Skipping step {step_id} using existing outputs.")
 
+            # Optional: normal mode sampling
             if step.get("normal_mode_sampling", False):
                 nms_params = step.get("normal_mode_sampling_parameters", {})
                 calc_type = nms_params.get("calc_type", "rm_imag")
@@ -440,7 +573,7 @@ class ChemRefiner:
                 else:
                     logging.info(f"Normal mode sampling requested for step {step_id}.")
                     input_template_path = os.path.join(self.template_dir, f"step{step_id}.inp")
-                    filtered_coordinates,filtered_ids = self.orca.normal_mode_sampling(
+                    filtered_coordinates, filtered_ids = self.orca.normal_mode_sampling(
                         file_paths=output_files,
                         calc_type=calc_type,
                         input_template=input_template_path,

--- a/src/chemrefine/core.py
+++ b/src/chemrefine/core.py
@@ -321,7 +321,7 @@ class ChemRefiner:
         logging.info("Starting ChemRefine pipeline.")
         previous_coordinates, previous_ids = None, None
 
-        valid_operations = {"OPT+SP","GOAT", "PES", "DOCKER", "SOLVATOR"}
+        valid_operations = {"OPT+SP", "GOAT", "PES", "DOCKER", "SOLVATOR"}
         valid_engines = {"dft", "mlff"}
 
         steps = self.config.get('steps', [])
@@ -345,7 +345,6 @@ class ChemRefiner:
                 mlff_task = mlff_config.get('task_name', 'mace_off')
                 bind_address = mlff_config.get('bind', '127.0.0.1:8888')
                 device = mlff_config.get('device', 'cuda')
-
                 logging.info(f"Using MLFF model '{mlff_model}' with task '{mlff_task}' for step {step_id}.")
             else:
                 mlff_model = step.get('model_name', 'medium')
@@ -359,7 +358,7 @@ class ChemRefiner:
             filtered_coordinates, filtered_ids, energies = (None, None, None)
             if self.skip_steps:
                 filtered_coordinates, filtered_ids, energies = self.handle_skip_step(
-                    step_id, operation,engine, sample_method, parameters
+                    step_id, operation, engine, sample_method, parameters
                 )
 
             if filtered_coordinates is None or filtered_ids is None:
@@ -393,7 +392,7 @@ class ChemRefiner:
                         model_name=mlff_model,
                         task_name=mlff_task,
                         device=device,
-                        bind=bind_address,
+                        bind=bind_address
                     )
 
                 self.submit_orca_jobs(
@@ -424,10 +423,50 @@ class ChemRefiner:
                 step_dir = os.path.join(self.output_dir, f"step{step_id}")
                 logging.info(f"Skipping step {step_id} using existing outputs.")
 
+            if step.get("normal_mode_sampling", False):
+                nms_params = step.get("normal_mode_sampling_parameters", {})
+                calc_type = nms_params.get("calc_type", "rm_imag")
+                displacement_vector = nms_params.get("displacement_vector", 1.0)
+                nms_random_displacements = nms_params.get("num_random_displacements", 1)
+                if 'output_files' not in locals() or not output_files:
+                    output_files = [
+                        os.path.join(step_dir, f)
+                        for f in os.listdir(step_dir)
+                        if f.endswith(".out") and not f.startswith("slurm")
+                    ]
+
+                if not output_files:
+                    logging.warning(f"No valid .out files found for normal mode sampling in step {step_id}. Skipping NMS.")
+                else:
+                    logging.info(f"Normal mode sampling requested for step {step_id}.")
+                    input_template_path = os.path.join(self.template_dir, f"step{step_id}.inp")
+                    filtered_coordinates,filtered_ids = self.orca.normal_mode_sampling(
+                        file_paths=output_files,
+                        calc_type=calc_type,
+                        input_template=input_template_path,
+                        slurm_template=self.template_dir,
+                        charge=step.get('charge', self.charge),
+                        multiplicity=step.get('multiplicity', self.multiplicity),
+                        output_dir=self.output_dir,
+                        operation=operation,
+                        engine=engine,
+                        model_name=mlff_model,
+                        step_number=step_id,
+                        structure_ids=filtered_ids,
+                        max_cores=self.max_cores,
+                        task_name=mlff_task,
+                        mlff_model=mlff_model,
+                        displacement_value=displacement_vector,
+                        device=device,
+                        bind=bind_address,
+                        orca_executable=self.orca_executable,
+                        scratch_dir=self.scratch_dir,
+                        num_random_modes=nms_random_displacements,
+                    )
+
             previous_coordinates, previous_ids = filtered_coordinates, filtered_ids
 
         logging.info("ChemRefine pipeline completed.")
-
 
 def main():
     ChemRefiner().run()

--- a/src/chemrefine/orca_interface.py
+++ b/src/chemrefine/orca_interface.py
@@ -368,10 +368,10 @@ class OrcaInterface:
                 continue
 
             if operation.lower() == 'solvator':
-                solvator_xyz_file = path.replace('.out', '.solvator.xyz')
+                solvator_xyz_file = path.replace('.out', '.solventbuild.xyz')
                 logging.info(f"Looking for Solvator structure file: {solvator_xyz_file}")
                 if os.path.exists(solvator_xyz_file):
-                    coords, ens = self.parse_solvator(solvator_xyz_file)
+                    coords, ens = self.parse_solvator_ensemble(solvator_xyz_file)
                     coordinates.extend(coords)
                     energies.extend(ens)
                 else:
@@ -549,41 +549,89 @@ class OrcaInterface:
 
         return coordinates, energies
     
-    def parse_solvator(self, file_path):
+    def parse_solvator_ensemble(self, file_path):
         """
-        Parses a solvator.xyz file containing a single XYZ structure without energy.
-        Assigns a placeholder energy value of 0.0.
+        Parse SOLVATOR multi-structure XYZ written by solventbuild, with repeating blocks:
 
-        Args:
-            file_path (str): Path to the .solvator.xyz file.
+            <natoms>\n
+            Energy -123.456789   (case-insensitive; variations allowed)\n
+            <symbol x y z> * natoms
 
-        Returns:
-            tuple: (coordinates_list, energies_list) — energy is set to 0.0.
+        Accepts scientific notation and minor variations like "total energy: -123.45".
+        Returns
+        -------
+        (coordinates_list, energies_list)
+            coordinates_list: list[list[tuple[str, float, float, float]]]
+            energies_list:    list[float | None]
         """
-        coordinates_list = []
-        energies_list = []
+        import re
+        import logging
 
-        with open(file_path, 'r') as file:
-            lines = file.readlines()
+        coords, energies = [], []
 
-        if len(lines) < 3:
-            raise ValueError(f"File {file_path} does not contain a valid XYZ structure.")
+        # Match the first float on the line, allowing "Energy", "Total Energy", optional ":" / "=" and sci notation
+        energy_re = re.compile(
+            r"(?:^\s*(?:energy|total\s+energy)\s*[:=]?\s*|\b)"
+            r"(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)",
+            re.IGNORECASE,
+        )
 
-        atom_count = int(lines[0].strip())
-        current_structure = []
+        with open(file_path, "r") as fh:
+            lines = fh.readlines()
 
-        for line in lines[2:2 + atom_count]:
-            tokens = line.strip().split()
-            if len(tokens) >= 4:
-                element = tokens[0]
-                x, y, z = map(float, tokens[1:4])
-                current_structure.append((element, x, y, z))
+        i, n = 0, len(lines)
+        while i < n:
+            line = lines[i].strip()
+            # find a block header that is a pure integer
+            if not line or not line.isdigit():
+                i += 1
+                continue
 
-        coordinates_list.append(current_structure)
-        energies_list.append(0.0)
+            natoms = int(line)
+            if i + 1 >= n:
+                break
 
-        logging.info(f"Parsed 1 solvator structure from {file_path} with placeholder energy 0.0.")
-        return coordinates_list, energies_list
+            # energy line (immediately after natoms)
+            m = energy_re.search(lines[i + 1])
+            energy = float(m.group(1)) if m else None
+
+            # atom block
+            block = []
+            start = i + 2
+            end = start + natoms
+            if end > n:
+                logging.warning(f"Unexpected EOF while reading atom block starting at line {i+1} in {file_path}.")
+                break
+
+            for j in range(start, end):
+                parts = lines[j].split()
+                if len(parts) < 4:
+                    logging.warning(f"Malformed coordinate line at {j+1} in {file_path}: {lines[j].rstrip()}")
+                    block = []
+                    break
+                sym = parts[0]
+                try:
+                    x, y, z = map(float, parts[1:4])
+                except ValueError:
+                    logging.warning(f"Non-numeric coordinates at {j+1} in {file_path}: {lines[j].rstrip()}")
+                    block = []
+                    break
+                block.append((sym, x, y, z))
+
+            if block and len(block) == natoms:
+                coords.append(block)
+                energies.append(energy)
+            else:
+                logging.warning(f"Skipping one SOLVATOR structure (bad/missing atom block near lines {start}-{end}).")
+
+            # jump to the next block
+            i = end
+
+        missing = sum(e is None for e in energies)
+        if missing:
+            logging.warning(f"{missing} SOLVATOR energy value(s) were missing in {file_path}.")
+        logging.info(f"Parsed {len(coords)} structures and {len(energies)} energies from {file_path}.")
+        return coords, energies
 
     def normal_mode_sampling(self,
                          file_paths,

--- a/src/chemrefine/orca_interface.py
+++ b/src/chemrefine/orca_interface.py
@@ -371,7 +371,7 @@ class OrcaInterface:
                 solvator_xyz_file = path.replace('.out', '.solvator.xyz')
                 logging.info(f"Looking for Solvator structure file: {solvator_xyz_file}")
                 if os.path.exists(solvator_xyz_file):
-                    coords, ens = self.parse_solvator_xyz(solvator_xyz_file)
+                    coords, ens = self.parse_solvator(solvator_xyz_file)
                     coordinates.extend(coords)
                     energies.extend(ens)
                 else:

--- a/src/chemrefine/run_mlff.sh
+++ b/src/chemrefine/run_mlff.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-python -m chemrefine.mlff_runner "$@"

--- a/src/chemrefine/utils.py
+++ b/src/chemrefine/utils.py
@@ -6,6 +6,7 @@ from .constants import HARTREE_TO_KCAL_MOL, R_KCAL_MOL_K, CSV_PRECISION
 from pathlib import Path
 import subprocess
 import getpass
+from typing import Optional
 
 logging.basicConfig(
     level=logging.INFO,
@@ -189,3 +190,372 @@ class Utility:
         """
         from ase.io import write
         write(output_file, atoms)
+
+    # --- Append below your existing imports in chemrefine/utils.py ---
+import os
+import json
+from typing import List, Dict, Optional
+
+_ID_PATTERN = re.compile(r"^step(?P<step>\d+)_structure_(?P<id>\d+)\.inp$", re.IGNORECASE)
+
+
+def extract_structure_id(inp_filename: str) -> Optional[int]:
+    """
+    Extract the integer structure ID from an input filename of the form
+    'step{N}_structure_{ID}.inp'.
+
+    Parameters
+    ----------
+    inp_filename : str
+        Basename or path to the .inp file.
+
+    Returns
+    -------
+    int | None
+        Parsed ID if pattern matches; otherwise None.
+    """
+    name = os.path.basename(inp_filename)
+    m = _ID_PATTERN.match(name)
+    return int(m.group("id")) if m else None
+
+
+def step_manifest_path(step_dir: str, step_number: int) -> str:
+    """
+    Compute the per-step manifest path.
+
+    Parameters
+    ----------
+    step_dir : str
+        Step folder path (e.g., outputs/step1).
+    step_number : int
+        Step index.
+
+    Returns
+    -------
+    str
+        JSON manifest path: 'step{n}_manifest.json' inside step_dir.
+    """
+    return os.path.join(step_dir, f"step{step_number}_manifest.json")
+
+
+def write_step_manifest(step_number: int, step_dir: str, input_files: List[str],
+                        operation: str, engine: str) -> None:
+    """
+    Create/update a per-step manifest mapping structure IDs to generated inputs.
+
+    Parameters
+    ----------
+    step_number : int
+        Step index.
+    step_dir : str
+        Step directory.
+    input_files : list[str]
+        Absolute (or relative) paths to the generated '.inp' files.
+    operation : str
+        Operation label (e.g., 'OPT+SP', 'GOAT').
+    engine : str
+        Engine label ('dft' or 'mlff').
+    """
+    manifest_file = step_manifest_path(step_dir, step_number)
+    records = []
+    for inp in input_files:
+        sid = extract_structure_id(inp)
+        records.append({
+            "structure_id": sid,
+            "input_file": os.path.basename(inp),
+            "output_file": None,
+            "operation": operation.upper(),
+            "engine": engine.lower(),
+        })
+    with open(manifest_file, "w") as f:
+        json.dump({"step": step_number, "records": records}, f, indent=2)
+
+
+def read_step_manifest(step_dir: str, step_number: int) -> Optional[Dict]:
+    """
+    Load a per-step manifest if it exists.
+
+    Parameters
+    ----------
+    step_dir : str
+        Step directory.
+    step_number : int
+        Step index.
+
+    Returns
+    -------
+    dict | None
+        Parsed manifest or None if missing.
+    """
+    p = step_manifest_path(step_dir, step_number)
+    if not os.path.exists(p):
+        return None
+    with open(p) as f:
+        return json.load(f)
+
+
+def update_step_manifest_outputs(step_dir: str, step_number: int,
+                                 output_files: List[str]) -> None:
+    """
+    Update the per-step manifest with resolved output filenames by matching stems.
+
+    Parameters
+    ----------
+    step_dir : str
+        Step directory.
+    step_number : int
+        Step index.
+    output_files : list[str]
+        Output files discovered after the run.
+
+    Notes
+    -----
+    Inputs and outputs typically share a stem:
+    'stepX_structure_ID' -> 'stepX_structure_ID.out' or similar.
+    """
+    manifest = read_step_manifest(step_dir, step_number)
+    if not manifest or "records" not in manifest:
+        return
+
+    # Build lookup from input stem -> record
+    by_input_stem = {}
+    for r in manifest["records"]:
+        stem = os.path.splitext(r["input_file"])[0]
+        by_input_stem[stem] = r
+
+    for outp in output_files:
+        out_stem = os.path.splitext(os.path.basename(outp))[0]
+        rec = by_input_stem.get(out_stem)
+        if rec is not None:
+            rec["output_file"] = os.path.basename(outp)
+
+    with open(step_manifest_path(step_dir, step_number), "w") as f:
+        json.dump(manifest, f, indent=2)
+
+
+def map_outputs_to_ids(step_dir: str, step_number: int, output_files: List[str]) -> List[int]:
+    """
+    Resolve structure IDs for outputs using the manifest; fall back to robust parsing
+    from output filenames (handles suffixes like '_atom46', '_trj', etc.) and prefix matching.
+
+    Returns
+    -------
+    list[int]
+        Structure IDs aligned with output_files order. Unresolved IDs are -1.
+    """
+    manifest = read_step_manifest(step_dir, step_number)
+    ids: List[int] = []
+
+    # Build indices from manifest
+    by_input_stem: Dict[str, Optional[int]] = {}
+    if manifest and "records" in manifest:
+        for r in manifest["records"]:
+            stem = os.path.splitext(r["input_file"])[0]  # e.g., 'step3_structure_0'
+            by_input_stem[stem] = r.get("structure_id")
+
+    input_stems = list(by_input_stem.keys())
+
+    for outp in output_files:
+        out_base = os.path.basename(outp)
+        out_stem, _ = os.path.splitext(out_base)
+
+        # 1) Exact stem match via manifest (when outputs share stem with inputs)
+        if out_stem in by_input_stem and by_input_stem[out_stem] is not None:
+            ids.append(int(by_input_stem[out_stem]))
+            continue
+
+        # 2) Prefix match: output stem starts with input stem (handles '_atom46', '_trj', etc.)
+        pref = [s for s in input_stems if out_stem.startswith(s)]
+        if len(pref) == 1 and by_input_stem[pref[0]] is not None:
+            ids.append(int(by_input_stem[pref[0]]))
+            continue
+
+        # 3) Regex extraction from the output name itself
+        sid = extract_structure_id_from_any_name(out_base)
+        if sid is not None:
+            ids.append(sid)
+            continue
+
+        # 4) Try a corresponding .inp with truncated suffix (common case)
+        #    e.g., 'step3_structure_0_atom46' -> try 'step3_structure_0.inp'
+        if "_" in out_stem:
+            truncated = out_stem.rsplit("_", 1)[0]
+            candidate_inp = os.path.join(step_dir, truncated + ".inp")
+            sid2 = extract_structure_id(candidate_inp)
+            if sid2 is not None:
+                ids.append(sid2)
+                continue
+
+        # 5) Last resort: -1 (caller should fail fast before creating inputs)
+        ids.append(-1)
+
+    return ids
+
+from typing import Sequence
+
+def validate_structure_ids_or_raise(structure_ids: Sequence[int], step_number: int) -> None:
+    """
+    Ensure all structure IDs are resolved (>= 0) and non-empty.
+    Raises ValueError if invalid, to prevent creating '..._-1.inp' files.
+
+    Parameters
+    ----------
+    structure_ids : Sequence[int]
+        IDs to validate.
+    step_number : int
+        Current step index.
+    """
+    if not structure_ids:
+        raise ValueError(f"Step {step_number}: empty structure ID list.")
+    if any((i is None) or (i < 0) for i in structure_ids):
+        bad = [i for i in structure_ids if (i is None) or (i < 0)]
+        raise ValueError(f"Step {step_number}: unresolved structure IDs present: {bad}")
+
+
+def registry_path(output_root: str) -> str:
+    """
+    Return the path to the global ID registry JSON in the pipeline output root.
+
+    Parameters
+    ----------
+    output_root : str
+        Pipeline root output directory.
+
+    Returns
+    -------
+    str
+        Registry file path.
+    """
+    return os.path.join(output_root, "id_registry.json")
+
+
+def get_next_id(output_root: str) -> int:
+    """
+    Return the next global integer structure ID and advance the registry.
+
+    Parameters
+    ----------
+    output_root : str
+        Pipeline root output directory.
+
+    Returns
+    -------
+    int
+        Next unique integer ID.
+    """
+    p = registry_path(output_root)
+    if os.path.exists(p):
+        with open(p) as f:
+            data = json.load(f)
+    else:
+        data = {"next_id": 0}
+    nid = data["next_id"]
+    data["next_id"] = nid + 1
+    with open(p, "w") as f:
+        json.dump(data, f, indent=2)
+    return nid
+
+def write_synthetic_manifest_for_ensemble(step_number, step_dir, n_structures, operation, engine, output_basename):
+    """
+    Create a synthetic manifest for a GOAT step where only one ensemble file exists.
+    Assigns sequential IDs [0..n_structures-1] and writes to step{N}_manifest.json.
+
+    Parameters
+    ----------
+    step_number : int
+        The step index (e.g., 1).
+    step_dir : str
+        Path to the step directory.
+    n_structures : int
+        Number of structures in the ensemble.
+    operation : str
+        Operation string (e.g., "GOAT").
+    engine : str
+        Engine string (e.g., "dft").
+    output_basename : str
+        Filename of the ensemble file (without directory).
+    """
+    manifest_path = os.path.join(step_dir, f"step{step_number}_manifest.json")
+    manifest_data = {
+        "step": step_number,
+        "operation": operation,
+        "engine": engine,
+        "structures": [],
+        "outputs": [output_basename],
+    }
+    for idx in range(n_structures):
+        manifest_data["structures"].append({
+            "id": idx,
+            "input": f"step{step_number}_structure_{idx}.inp",
+            "output": output_basename
+        })
+    with open(manifest_path, "w") as f:
+        json.dump(manifest_data, f, indent=2)
+    logging.info(f"Wrote synthetic manifest for step {step_number} with {n_structures} IDs at {manifest_path}.")
+
+
+def get_ensemble_ids(step_dir, step_number, n_structures, operation, engine, output_basename):
+    """
+    Retrieve sequential IDs for a GOAT ensemble file. If the manifest does not exist,
+    generate it using write_synthetic_manifest_for_ensemble.
+
+    Parameters
+    ----------
+    step_dir : str
+        Path to the step directory.
+    step_number : int
+        Step index.
+    n_structures : int
+        Number of structures in the ensemble.
+    operation : str
+        Operation string.
+    engine : str
+        Engine string.
+    output_basename : str
+        Ensemble file name.
+
+    Returns
+    -------
+    list[int]
+        Sequential IDs [0..n_structures-1].
+    """
+    manifest_path = os.path.join(step_dir, f"step{step_number}_manifest.json")
+    if not os.path.exists(manifest_path):
+        logging.info(f"Manifest for step {step_number} not found; creating synthetic manifest.")
+        write_synthetic_manifest_for_ensemble(
+            step_number, step_dir, n_structures, operation, engine, output_basename
+        )
+    return list(range(n_structures))
+
+import os
+from typing import Optional
+
+_ID_ANYWHERE_RE = re.compile(
+    r"step(?P<step>\d+)_structure_(?P<id>\d+)(?:_|\.|$)", re.IGNORECASE
+)
+
+def extract_structure_id_from_any_name(name: str) -> Optional[int]:
+    """
+    Extract a structure ID from any filename or stem containing the pattern
+    'step{N}_structure_{ID}[...optional suffixes...]'.
+
+    Examples
+    --------
+    'step3_structure_0_atom46.out' → 0
+    'step4_structure_12_trj.xyz'   → 12
+    'step2_structure_5.out'        → 5
+
+    Parameters
+    ----------
+    name : str
+        A basename, full path, or stem.
+
+    Returns
+    -------
+    int | None
+        Parsed ID if found, else None.
+    """
+    base = os.path.basename(name)
+    stem = os.path.splitext(base)[0]
+    m = _ID_ANYWHERE_RE.search(stem)
+    return int(m.group("id")) if m else None


### PR DESCRIPTION
Summary

This PR introduces support for running custom MLFF models via a user-defined model_path, alongside improvements to stability, sampling flow, and structure ID handling. It also removes deprecated code and simplifies the client/server interfaces.

Key Changes

Custom MLFF Support

Added model_path option across core.py, mlff.py, and server.py.

Enables running user-provided MACE models in addition to pretrained models.

Updated server CLI to validate either --model or --model-path.

Logging improvements to indicate when a custom model is loaded.

Core Pipeline Updates

Extended submit_orca_jobs and run() to propagate model_path.

Adjusted prepare_step1_directory and prepare_subsequent_step_directory signatures for clarity.

Normal mode sampling (NMS) now correctly advances to the next step instead of recalculating.

MLFF Calculator

Implemented _setup_custom_mace() to load models from a given path.

Improved logging for MACE, FAIRChem, and CHGNet selections.

Validation Improvements

validate_structure_ids_or_raise now supports both int and str IDs.

Provides clearer error messages for invalid or empty IDs.

Housekeeping

Removed deprecated run_mlff.sh.

Cleaned whitespace and minor style issues.

Deleted unused argparse entries in client.py.

Impact

These changes make ChemRefine more flexible by allowing external MACE models to be used seamlessly. They also improve robustness in downstream workflows (e.g., NMS sampling and structure ID handling).

Stats

+359 / -140 lines

6 files modified, 1 file removed