### PR TITLE
 Fixed the server process backgrounding and added a loop to check the server startup 

### DIFF
--- a/src/chemrefine/orca_interface.py
+++ b/src/chemrefine/orca_interface.py
@@ -283,16 +283,29 @@ class OrcaJobSubmitter:
                 f.write("# Start MLFF socket server before ORCA\n")
                 if model_path:
                     f.write(
-                        f"python -m chemrefine.server --model-path {model_path} --device {device} --bind {bind} & > $OUTPUT_DIR/server.log 2>&1 & \n"
+                        f"python -m chemrefine.server --model-path {model_path} --device {device} --bind {bind} > $OUTPUT_DIR/server.log 2>&1 & \n"
                     )
                 else:
                     f.write(
-                        f"python -m chemrefine.server --model {model_name} --task-name {task_name} --device {device} --bind {bind} & > $OUTPUT_DIR/server.log 2>&1 & \n"
+                        f"python -m chemrefine.server --model {model_name} --task-name {task_name} --device {device} --bind {bind} > $OUTPUT_DIR/server.log 2>&1 & \n"
                     )
 
                 f.write("SERVER_PID=$!\n")
+                f.write("for i in {1..120}; do\n")
+                f.write("if curl -s http://127.0.0.1:8888 > /dev/null; then\n")
+                f.write("echo Server is ready!\n")
+                f.write("break\n")
+                f.write("fi\n")
+                f.write("if ! ps -p $SERVER_PID > /dev/null; then\n")
+                f.write("echo Server crashed during startup!\n")
+                f.write("cat $OUTPUT_DIR/server.log\n")
+                f.write("exit 1\n")
+                f.write("fi\n")
+                f.write("sleep 1\n")
+                f.write("done\n")
+                
                 f.write("trap 'kill $SERVER_PID 2>/dev/null' EXIT\n")
-                f.write("sleep 10\n")
+                
                 f.write(
                     f"$ORCA_EXEC {input_file.name} > $OUTPUT_DIR/{job_name}.out || {{ echo 'Error: ORCA execution failed.'; kill $SERVER_PID; exit 1; }}\n"
                 )


### PR DESCRIPTION
1. Fixed the server process backgrounding to correctly capture output in the server.log
2. Added a loop to identify the status of server. The continuation is expected as soon as the server is up and running
3. An Exit is added to the slurm script in case the server crashed
4. The total wait time for server startup check is 120s. beyond this the workfow continues regardless of the server actually listning. (If the server did not crash on startup)