### PR TITLE
Add PySCF tensor extraction, save, and print helpers

### DIFF
--- a/src/chemrefine/core.py
+++ b/src/chemrefine/core.py
@@ -1219,6 +1219,14 @@ class ChemRefiner:
                 raise ValueError(f"[step {ctx.step_number}] pyscf engine requires 'pyscf: functional' (or 'xc').")
             if ctx.engine_cfg.device not in {"cpu", "cuda"}:
                 raise ValueError(f"[step {ctx.step_number}] pyscf device must be 'cpu' or 'cuda'.")
+            extras = ctx.engine_cfg.extras or {}
+            if not isinstance(extras.get("save_tensors", False), bool):
+                raise ValueError(f"[step {ctx.step_number}] pyscf.save_tensors must be true/false.")
+            if not isinstance(extras.get("localized", False), bool):
+                raise ValueError(f"[step {ctx.step_number}] pyscf.localized must be true/false.")
+            tensor_folder = extras.get("tensor_folder", "tensors")
+            if not isinstance(tensor_folder, str) or not tensor_folder.strip():
+                raise ValueError(f"[step {ctx.step_number}] pyscf.tensor_folder must be a non-empty string.")
             ###____RUN____###
 
     def _extract_engine_config(self, step: dict, engine: str) -> EngineConfig:
@@ -1252,13 +1260,18 @@ class ChemRefiner:
             if device is None:
                 device = "cuda" if cfg.get("gpu", False) else "cpu"
 
+            extras = dict(cfg)
+            extras["save_tensors"] = bool(cfg.get("save_tensors", False))
+            extras["localized"] = bool(cfg.get("localized", False))
+            extras["tensor_folder"] = cfg.get("tensor_folder", "tensors")
+
             return EngineConfig(
                 engine="pyscf",
                 device=device,
                 bind=cfg.get("bind", default_bind),
                 basis=cfg.get("basis", step.get("basis")),               # allow top-level fallback if you want
                 functional=cfg.get("functional", cfg.get("xc", "pbe")),   # support xc alias; default pbe
-                extras=dict(cfg),
+                extras=extras,
             )
 
         # ----------------

--- a/src/chemrefine/pyscf_server.py
+++ b/src/chemrefine/pyscf_server.py
@@ -3,14 +3,16 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 import sys
 import time
 from typing import Any, Dict, Tuple
 
+import numpy as np
 import waitress
 from flask import Flask, request, jsonify
 
-from pyscf import gto, scf, dft, lib
+from pyscf import ao2mo, dft, gto, lib, scf
 
 BOHR_PER_ANG = 1.0 / 0.529177210903  # Å -> Bohr
 
@@ -43,6 +45,64 @@ DEFAULTS: Dict[str, Any] = {
 }
 
 logger = logging.getLogger("pyscfserver")
+
+
+def get_active_space_tensors(mol, mf, localized: bool = False):
+    """
+    Extract one- and two-electron tensors in the current MO basis.
+
+    When ``localized`` is True, apply Boys localization separately to occupied
+    and virtual orbitals before integral transformation.
+    """
+    nuc = mol.energy_nuc()
+    ao_kin = mol.intor("int1e_kin")
+    ao_nuc = mol.intor("int1e_nuc")
+    ao_obi = ao_kin + ao_nuc
+    ao_eri = mol.intor("int2e")
+    coeff = mf.mo_coeff
+
+    if localized:
+        from pyscf import lo
+
+        nocc = int((mf.mo_occ > 0).sum())
+        occ_idx = np.arange(0, nocc)
+        vir_idx = np.arange(nocc, coeff.shape[1])
+
+        coeff_occ = coeff[:, occ_idx]
+        coeff_vir = coeff[:, vir_idx]
+
+        loc_occ = lo.Boys(mol, coeff_occ).kernel(verbose=4)
+        loc_vir = lo.Boys(mol, coeff_vir).kernel(verbose=4)
+        mo_coeff_final = np.column_stack((loc_occ, loc_vir))
+    else:
+        mo_coeff_final = coeff
+
+    h1_spatial = mo_coeff_final.T @ ao_obi @ mo_coeff_final
+    h2_spatial = ao2mo.incore.full(ao_eri, mo_coeff_final)
+    return nuc, h1_spatial, h2_spatial
+
+
+def save_tensors(b: float, h0, h1, h2, folder: str = "tensors") -> str:
+    """Save tensor tuple to a compressed ``npz`` file and return the path."""
+    if not os.path.exists(folder):
+        os.makedirs(folder)
+
+    filename = os.path.join(folder, f"{b:2.1f}_tensors.npz")
+    np.savez_compressed(filename, hc=h0, h1e=h1, h2e=h2)
+    print(f"Tensors saved to {filename}")
+    return filename
+
+
+def print_tensors_file(npz_file: str) -> None:
+    """Pretty-print the tensors stored in a ``save_tensors`` file."""
+    data = np.load(npz_file)
+    print(f"File: {npz_file}")
+    print("hc (scalar):")
+    print(data["hc"])
+    print("h1e (one-electron tensor):")
+    print(data["h1e"])
+    print("h2e (two-electron tensor):")
+    print(data["h2e"])
 
 
 def _gpu_dft_classes():


### PR DESCRIPTION
### Motivation
- Provide utilities to extract one- and two-electron integrals from a converged PySCF `mol`/`mf` so integrals can be inspected or exported for downstream active-space workflows. 
- Allow optional orbital localization (Boys) prior to AO->MO transformation to support localized active-space constructions. 
- Persist integrals to disk in a compact `.npz` form and provide a simple printer for quick inspection.

### Description
- Added `get_active_space_tensors(mol, mf, localized: bool = False)` to `src/chemrefine/pyscf_server.py` which returns `(h0, h1_spatial, h2_spatial)` computed from AO integrals and the current MO coefficients, using `ao2mo.incore.full` for the 2-electron transform.
- When `localized=True` the function performs Boys localization separately on occupied and virtual subspaces before forming the final MO coefficient matrix.
- Added `save_tensors(b: float, h0, h1, h2, folder: str = "tensors")` to save tensors as a compressed `.npz` with keys `hc`, `h1e`, `h2e` and return the saved path.
- Added `print_tensors_file(npz_file: str)` to load and print the saved `hc`, `h1e`, and `h2e` arrays for quick inspection, and introduced required imports (`os`, `numpy`, `ao2mo`) to support these helpers.

### Testing
- Ran `python -m py_compile src/chemrefine/pyscf_server.py` and the module compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f281c8babc8323b7d6f0a1bf17bf26)